### PR TITLE
Include managed cluster IDs after they are upgraded to 4.X

### DIFF
--- a/pkg/monitor/clustermonitor.go
+++ b/pkg/monitor/clustermonitor.go
@@ -181,7 +181,10 @@ func (m *Monitor) updateCluster(managedCluster *clusterv1.ManagedCluster) {
 
 	clusterToUpdate := managedCluster.GetName()
 	clusterVendor, version, clusterID := GetClusterClaimInfo(managedCluster)
-	clusterIdx, found := Find(m.ManagedClusterInfo, types.ManagedClusterInfo{Namespace: clusterToUpdate, ClusterID: clusterID})
+	clusterIdx, found := Find(m.ManagedClusterInfo, types.ManagedClusterInfo{
+		Namespace: clusterToUpdate,
+		ClusterID: clusterID,
+	})
 	if found && clusterID != m.ManagedClusterInfo[clusterIdx].ClusterID {
 		// If the cluster ID has changed update it - otherwise do nothing.
 		glog.Infof("Updating %s from Insights cluster list", clusterToUpdate)


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#8621

### Description of changes
- Include managed cluster IDs after they are upgraded to 4.X
