### PR TITLE
Add ability to set ca cert to use qaprodauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,7 @@ Uses Red Hat Connected Customer Experience (CCX) to provide health check insight
     ```
 3. Log into your development cluster with `oc login ...`.
     > **Alternative:** set the `KUBECONFIG` environment variable to some other kubernetes config file.
-4. Set env vars to use qaprodauth server. qaprodauth allows devs to manually generate Insights on a specific cluster
-    ```
-    CCX_SERVER=https://qaprodauth.cloud.redhat.com/api/insights-results-aggregator/v1
-    CCX_TOKEN=Basic: <echo -n qaprodauth-username:quaprodauth-password | base64>
-    CACERT=<obtained by running generate_qaprodauth_cert.sh>
-    ```
-5. Run the program
+4. Run the program
     ```
     make run
     ```
@@ -31,7 +25,7 @@ Control the behavior of this service with these environment variables.
 Name             | Required | Default Value                           | Description
 ---------------- | -------- | --------------------------------------- | -----------
 HTTP_TIMEOUT     | no       | 180000                                  | 3 minute timeout to process a single requests
-CCX_SERVER       | no       | http://localhost:8080/api/v1/clusters | CCX server url (prod will use: `https://cloud.redhat.com/api/insights-results-aggregator/v1`)
+CCX_SERVER       | no       | http://localhost:8080/api/v1/clusters   | CCX server url (prod will use: `https://cloud.redhat.com/api/insights-results-aggregator/v1`)
 CCX_TOKEN        | no       | Not set                                 | If not set client will get cloud.openshift.com token from secret `openshift-config`
 POLL_INTERVAL    | no       | 30                                      | 30 minute default polling interval cloud.redhat.com
 REQUEST_INTERVAL | no       | 1                                       | 1 second Interval between 2 consecutive Insights requests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # insights-client
 
-Uses Red Hat Connected Customer Experience (CCX) to provide health check insights . The insights-client will create a Custom Resource (PolicyReport) for each insight specific to each cluster under management.
+Uses Red Hat Connected Customer Experience (CCX) to provide health check insights for all managed cluster (clusters have to be Openshift versioned >= 4.X). The insights-client will create a Custom Resource (PolicyReport) for each cluster that contains all Insight violations.
+
+## Development
+
+1. Install dependencies
+    ```
+    make deps
+    ```
+2. Generate self-signed certificate for development
+    ```
+    sh setup.sh
+    ```
+3. Log into your development cluster with `oc login ...`.
+    > **Alternative:** set the `KUBECONFIG` environment variable to some other kubernetes config file.
+4. Set env vars to use qaprodauth server. qaprodauth allows devs to manually generate Insights on a specific cluster
+    ```
+    CCX_SERVER=https://qaprodauth.cloud.redhat.com/api/insights-results-aggregator/v1
+    CCX_TOKEN=Basic: <echo -n qaprodauth-username:quaprodauth-password | base64>
+    CACERT=<obtained by running generate_qaprodauth_cert.sh>
+    ```
+5. Run the program
+    ```
+    make run
+    ```
+
+### Environment Variables
+Control the behavior of this service with these environment variables.
+
+Name             | Required | Default Value                           | Description
+---------------- | -------- | --------------------------------------- | -----------
+HTTP_TIMEOUT     | no       | 180000                                  | 3 minute timeout to process a single requests
+CCX_SERVER       | no       | http://localhost:8080/api/v1/clusters | CCX server url (prod will use: `https://cloud.redhat.com/api/insights-results-aggregator/v1`)
+CCX_TOKEN        | no       | Not set                                 | If not set client will get cloud.openshift.com token from secret `openshift-config`
+POLL_INTERVAL    | no       | 30                                      | 30 minute default polling interval cloud.redhat.com
+REQUEST_INTERVAL | no       | 1                                       | 1 second Interval between 2 consecutive Insights requests
+CACERT           | no       | Not set                                 | Used for dev & test ONLY

--- a/generate_qaprodauth_cert.sh
+++ b/generate_qaprodauth_cert.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+SERVER=qaprodauth.cloud.redhat.com
+openssl s_client -connect $SERVER:443 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'

--- a/generate_qaprodauth_cert.sh
+++ b/generate_qaprodauth_cert.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-SERVER=qaprodauth.cloud.redhat.com
-openssl s_client -connect $SERVER:443 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ const (
 	DEFAULT_HTTP_TIMEOUT     = 180000                                  // 3 minutes HTTP Timeout
 	DEFAULT_USE_MOCK         = false                                   // Use Mocked Cluster ID ?
 	DEFAULT_CCX_SERVER       = "http://localhost:8080/api/v1/clusters" // For local use only
-	DEFAULT_POLL_INTERVAL    = 1                                      // 30mins default polling interval cloud.redhat.com
+	DEFAULT_POLL_INTERVAL    = 30                                      // 30mins default polling interval cloud.redhat.com
 	DEFAULT_REQUEST_INTERVAL = 1                                       // 1 second Interval between 2 consecutive requests
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2021 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+
 package config
 
 import (
@@ -15,26 +16,27 @@ const (
 	DEFAULT_HTTP_TIMEOUT     = 180000                                  // 3 minutes HTTP Timeout
 	DEFAULT_USE_MOCK         = false                                   // Use Mocked Cluster ID ?
 	DEFAULT_CCX_SERVER       = "http://localhost:8080/api/v1/clusters" // For local use only
-	DEFAULT_POLL_INTERVAL    = 30                                      // 30mins default polling interval cloud.redhat.com
+	DEFAULT_POLL_INTERVAL    = 1                                      // 30mins default polling interval cloud.redhat.com
 	DEFAULT_REQUEST_INTERVAL = 1                                       // 1 second Interval between 2 consecutive requests
 )
 
 // Config - Define a config type to hold our config properties.
 type Config struct {
 	ServicePort     string `env:"SERVICE_PORT"`
-	HTTPTimeout     int    `env:"HTTP_TIMEOUT"` // timeout when the http server should drop connections
-	UseMock         bool   `env:"USE_MOCK"`     // Use Mock Server or actual endpoint
+	HTTPTimeout     int    `env:"HTTP_TIMEOUT"`     // timeout when the http server should drop connections
+	UseMock         bool   `env:"USE_MOCK"`         // Use Mock Server or actual endpoint
 	CCXServer       string `env:"CCX_SERVER"`
 	KubeConfig      string `env:"KUBECONFIG"`       // Local kubeconfig path
 	CCXToken        string `env:"CCX_TOKEN"`        // Token to access CCX server , when pull-secret cannot be used
 	PollInterval    int    `env:"POLL_INTERVAL"`    // Pollig interval to reports from cloud.redhat.com
 	RequestInterval int    `env:"REQUEST_INTERVAL"` // Interval between 2 consequent requests
+	CACert          string `env:"CACert"`           // base64 encoded caCert used for dev & test
 }
 
 // Cfg service configuration
 var Cfg = Config{}
 
-var Message = "Using %s from environment: %s"
+var message = "Using %s from environment: %s"
 
 func init() {
 	// If environment variables are set, use those values constants
@@ -42,6 +44,7 @@ func init() {
 	setDefault(&Cfg.ServicePort, "SERVICE_PORT", DEFAULT_SERVICE_PORT)
 	setDefault(&Cfg.CCXServer, "CCX_SERVER", DEFAULT_CCX_SERVER)
 	setDefault(&Cfg.CCXToken, "CCX_TOKEN", "")
+	setDefault(&Cfg.CACert, "CACert", "")
 	setDefaultInt(&Cfg.HTTPTimeout, "HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT)
 	setDefaultInt(&Cfg.PollInterval, "POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
 	setDefaultInt(&Cfg.RequestInterval, "REQUEST_INTERVAL", DEFAULT_REQUEST_INTERVAL)
@@ -57,7 +60,7 @@ func init() {
 
 func setDefault(field *string, env, defaultVal string) {
 	if val := os.Getenv(env); val != "" {
-		glog.V(2).Infof(Message, env, val)
+		glog.V(2).Infof(message, env, val)
 		*field = val
 	} else if *field == "" && defaultVal != "" {
 		glog.V(2).Infof("%s not set, using default value: %s", env, defaultVal)
@@ -67,7 +70,7 @@ func setDefault(field *string, env, defaultVal string) {
 
 func setDefaultInt(field *int, env string, defaultVal int) {
 	if val := os.Getenv(env); val != "" {
-		glog.Infof(Message, env, val)
+		glog.Infof(message, env, val)
 		var err error
 		*field, err = strconv.Atoi(val)
 		if err != nil {
@@ -81,7 +84,7 @@ func setDefaultInt(field *int, env string, defaultVal int) {
 
 func setDefaultBool(field *bool, env string, defaultVal bool) {
 	if val := os.Getenv(env); val != "" {
-		glog.Infof(Message, env, val)
+		glog.Infof(message, env, val)
 		var err error
 		*field, err = strconv.ParseBool(val)
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,6 @@ import (
 const (
 	DEFAULT_SERVICE_PORT     = ":3030"
 	DEFAULT_HTTP_TIMEOUT     = 180000                                  // 3 minutes HTTP Timeout
-	DEFAULT_USE_MOCK         = false                                   // Use Mocked Cluster ID ?
 	DEFAULT_CCX_SERVER       = "http://localhost:8080/api/v1/clusters" // For local use only
 	DEFAULT_POLL_INTERVAL    = 30                                      // 30mins default polling interval cloud.redhat.com
 	DEFAULT_REQUEST_INTERVAL = 1                                       // 1 second Interval between 2 consecutive requests
@@ -24,7 +23,6 @@ const (
 type Config struct {
 	ServicePort     string `env:"SERVICE_PORT"`
 	HTTPTimeout     int    `env:"HTTP_TIMEOUT"`     // timeout when the http server should drop connections
-	UseMock         bool   `env:"USE_MOCK"`         // Use Mock Server or actual endpoint
 	CCXServer       string `env:"CCX_SERVER"`
 	KubeConfig      string `env:"KUBECONFIG"`       // Local kubeconfig path
 	CCXToken        string `env:"CCX_TOKEN"`        // Token to access CCX server , when pull-secret cannot be used
@@ -48,7 +46,6 @@ func init() {
 	setDefaultInt(&Cfg.HTTPTimeout, "HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT)
 	setDefaultInt(&Cfg.PollInterval, "POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
 	setDefaultInt(&Cfg.RequestInterval, "REQUEST_INTERVAL", DEFAULT_REQUEST_INTERVAL)
-	setDefaultBool(&Cfg.UseMock, "USE_MOCK", DEFAULT_USE_MOCK)
 	defaultKubePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	if _, err := os.Stat(defaultKubePath); os.IsNotExist(err) {
 		// set default to empty string if path does not reslove

--- a/pkg/monitor/clustermonitor.go
+++ b/pkg/monitor/clustermonitor.go
@@ -206,7 +206,7 @@ func (m *Monitor) updateCluster(managedCluster *clusterv1.ManagedCluster) {
 		glog.Infof("Updating %s from Insights cluster list", clusterToUpdate)
 		m.ManagedClusterInfo[clusterIdx] = types.ManagedClusterInfo{
 			ClusterID: clusterID,
-			Namespace: managedCluster.GetName(),
+			Namespace: clusterToUpdate,
 		}
 		return
 	}

--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -206,14 +206,14 @@ func updatePolicyReportViolations(
 
 	if err != nil {
 		glog.Infof(
-			"Error adding new PolicyReport violations for cluster %s (%s): %v",
+			"Error updating Insights for cluster %s (%s): %v",
 			clusterInfo.Namespace,
 			clusterInfo.ClusterID,
 			err,
 		)
 	} else {
 		glog.Infof(
-			"Successfully added new PolicyReport violations for cluster %s (%s)",
+			"Successfully updated Insights for cluster %s (%s)",
 			clusterInfo.Namespace,
 			clusterInfo.ClusterID,
 		)

--- a/pkg/retriever/contentretriever.go
+++ b/pkg/retriever/contentretriever.go
@@ -19,8 +19,8 @@ var ContentsMap map[string]map[string]interface{}
 var lock = sync.RWMutex{}
 
 // GetContentRequest - Creates GET request for contents
-func (r *Retriever) GetContentRequest(ctx context.Context, clusterID string) (*http.Request, error) {
-	glog.Infof("Creating Content Request for cluster %s using  URL %s :", clusterID, r.ContentURL)
+func (r *Retriever) GetContentRequest(ctx context.Context, hubID string) (*http.Request, error) {
+	glog.Infof("Creating Content Request for cluster %s using  URL %s :", hubID, r.ContentURL)
 	req, err := http.NewRequest("GET", r.ContentURL, nil)
 	if err != nil {
 		glog.Warningf("Error creating HttpRequest with endpoint %s, %v", r.ContentURL, err)
@@ -29,7 +29,7 @@ func (r *Retriever) GetContentRequest(ctx context.Context, clusterID string) (*h
 	// userAgent for value will be updated to insights-client once the
 	// the task https://github.com/RedHatInsights/insights-results-smart-proxy/issues/450
 	// is completed
-	userAgent := "insights-operator/v1.0.0+b653953-b653953ed174001d5aca50b3515f1fa6f6b28728 cluster/" + clusterID
+	userAgent := "insights-operator/v1.0.0+b653953-b653953ed174001d5aca50b3515f1fa6f6b28728 cluster/" + hubID
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Authorization", r.Token)
@@ -61,15 +61,15 @@ func (r *Retriever) CallContents(req *http.Request) (types.ContentsResponse, err
 }
 
 // Function to make a GET HTTP call to get all the contents for reports
-func (r *Retriever) retrieveCCXContent(clusterID string) int {
-	req, err := r.GetContentRequest(context.TODO(), clusterID)
+func (r *Retriever) retrieveCCXContent(hubID string) int {
+	req, err := r.GetContentRequest(context.TODO(), hubID)
 	if err != nil {
 		glog.Warningf("Error creating HttpRequest with endpoint %s, %v", r.ContentURL, err)
 		return -1
 	}
 	contents, err := r.CallContents(req)
 	if err != nil {
-		glog.Warningf("Error calling for contents %s, %v", clusterID, err)
+		glog.Warningf("Error calling for contents %s, %v", hubID, err)
 		return -1
 	}
 	r.createContents(contents)

--- a/pkg/retriever/reportretriever.go
+++ b/pkg/retriever/reportretriever.go
@@ -47,7 +47,7 @@ func NewRetriever(ccxurl string, ContentURL string, client *http.Client,
 		if config.Cfg.CACert != "" {
 			// If caCert is defiend in Insights-client deployment - we need to use it in http client
 			// This will be used only for dev & testing purposes to use qaprodauth.cloud.redhat.com
-			decodedCert, err := b64.URLEncoding.DecodeString(config.Cfg.Cert)
+			decodedCert, err := b64.URLEncoding.DecodeString(config.Cfg.CACert)
 			if err != nil {
 				// Exit because this is an unrecoverable configuration problem.
 				glog.Fatal("Error decoding CA certificate. Certificate must be a base64 encoded CA certificate. Error: ", err)

--- a/pkg/retriever/reportretriever.go
+++ b/pkg/retriever/reportretriever.go
@@ -233,6 +233,9 @@ func (r *Retriever) GetPolicyInfo(
 ) (types.ProcessorData, error) {
 	glog.Infof("Creating Policy Info for cluster %s (%s)", cluster.Namespace, cluster.ClusterID)
 	reports := types.Reports{}
+	for clusterErrored := range responseBody.Errors {
+        glog.Warningf("Error occured while requesting Insights for cluster: %s", clusterErrored)
+    }
 
 	// loop through the clusters in the response and pull out the report violations
 	for reportClusterID := range responseBody.Reports {

--- a/pkg/retriever/reportretriever.go
+++ b/pkg/retriever/reportretriever.go
@@ -6,6 +6,9 @@ package retriever
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	b64 "encoding/base64"
 	"encoding/json"
 	e "errors"
 	"fmt"
@@ -41,7 +44,29 @@ type serializedAuth struct {
 func NewRetriever(ccxurl string, ContentURL string, client *http.Client,
 	token string) *Retriever {
 	if client == nil {
-		client = &http.Client{}
+		if config.Cfg.CACert != "" {
+			// If caCert is defiend in Insights-client deployment - we need to use it in http client
+			// This will be used only for dev & testing purposes to use qaprodauth.cloud.redhat.com
+			decodedCert, err := b64.URLEncoding.DecodeString(config.Cfg.Cert)
+			if err != nil {
+				// Exit because this is an unrecoverable configuration problem.
+				glog.Fatal("Error decoding CA certificate. Certificate must be a base64 encoded CA certificate. Error: ", err)
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(decodedCert)
+
+			tlsCfg := &tls.Config{
+				RootCAs: caCertPool,
+			}
+
+			tr := &http.Transport{
+				TLSClientConfig: tlsCfg,
+			}
+
+			client = &http.Client{Transport: tr}
+		} else {
+			client = &http.Client{}
+		}
 	}
 	r := &Retriever{
 		Client:     client,
@@ -231,7 +256,10 @@ func (r *Retriever) GetPolicyInfo(
 			}, nil
 		}
 	}
-	return types.ProcessorData{}, nil
+	return types.ProcessorData{
+		ClusterInfo: cluster,
+		Reports:     types.Reports{},
+	}, nil
 }
 
 // FetchClusters forwards the managed clusters to RetrieveCCXReports function

--- a/pkg/retriever/reportretriever.go
+++ b/pkg/retriever/reportretriever.go
@@ -56,7 +56,8 @@ func NewRetriever(ccxurl string, ContentURL string, client *http.Client,
 			caCertPool.AppendCertsFromPEM(decodedCert)
 
 			tlsCfg := &tls.Config{
-				RootCAs: caCertPool,
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caCertPool,
 			}
 
 			tr := &http.Transport{

--- a/pkg/types/policyReportTypes.go
+++ b/pkg/types/policyReportTypes.go
@@ -4,6 +4,7 @@ package types
 
 type ResponseBody struct {
 	Reports map[string]interface{} `json:"reports"`
+	Errors  map[string]string      `json:"errors"`
 }
 
 type PostBody struct {


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#12202

### Description of changes
Add handling for an env var `CACert` that will enable communication with qaprodauth for dev and testing.

`/hold` /hold
