### PR TITLE
Create a configmap to store all insight content data

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		refreshToken = false
 	}
 	//start triggering reports for clusters
-	go ret.FetchClusters(monitor, fetchClusterIDs, refreshToken)
+	go ret.FetchClusters(monitor, fetchClusterIDs, refreshToken, hubID, dynamicClient)
 
 	router := mux.NewRouter()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ const (
 	DEFAULT_CCX_SERVER       = "http://localhost:8080/api/v1/clusters" // For local use only
 	DEFAULT_POLL_INTERVAL    = 30                                      // 30mins default polling interval cloud.redhat.com
 	DEFAULT_REQUEST_INTERVAL = 1                                       // 1 second Interval between 2 consecutive requests
+	DEFAULT_POD_NAMESPACE    = "kube-system"                           // Namespace of insights-client pod
 )
 
 // Config - Define a config type to hold our config properties.
@@ -26,9 +27,10 @@ type Config struct {
 	CCXServer       string `env:"CCX_SERVER"`
 	KubeConfig      string `env:"KUBECONFIG"`       // Local kubeconfig path
 	CCXToken        string `env:"CCX_TOKEN"`        // Token to access CCX server , when pull-secret cannot be used
-	PollInterval    int    `env:"POLL_INTERVAL"`    // Pollig interval to reports from cloud.redhat.com
+	PollInterval    int    `env:"POLL_INTERVAL"`    // Polling interval to reports from cloud.redhat.com
 	RequestInterval int    `env:"REQUEST_INTERVAL"` // Interval between 2 consequent requests
 	CACert          string `env:"CACert"`           // base64 encoded caCert used for dev & test
+	PodNamespace    string `env:"POD_NAMESPACE"`    // Namespace of insights-client pod
 }
 
 // Cfg service configuration
@@ -43,6 +45,7 @@ func init() {
 	setDefault(&Cfg.CCXServer, "CCX_SERVER", DEFAULT_CCX_SERVER)
 	setDefault(&Cfg.CCXToken, "CCX_TOKEN", "")
 	setDefault(&Cfg.CACert, "CACert", "")
+	setDefault(&Cfg.PodNamespace, "POD_NAMESPACE", DEFAULT_POD_NAMESPACE)
 	setDefaultInt(&Cfg.HTTPTimeout, "HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT)
 	setDefaultInt(&Cfg.PollInterval, "POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
 	setDefaultInt(&Cfg.RequestInterval, "REQUEST_INTERVAL", DEFAULT_REQUEST_INTERVAL)

--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -62,8 +62,6 @@ func getPolicyReportResults(
 						"created_at": contentData.PublishDate,
 						// *** total_risk is not currently included in content data, but being added by CCX team.
 						"total_risk": strconv.Itoa(contentData.Likelihood),
-						"reason":     contentData.Reason,     // Need to figure out where to store this value outside of the PR
-						"resolution": contentData.Resolution, // Need to figure out where to store this value outside of the PR
 						"component":  report.Component,
 						// TODO Need to store extra data here for templating changes in UI
 					},
@@ -89,7 +87,7 @@ func (p *Processor) createUpdatePolicyReports(input chan types.ProcessorData, dy
 		glog.Info("Missing managed cluster ID and/or Namespace nothing to process")
 		return
 	}
-	glog.Info("Managed cluster ID and/or Namespace present in data")
+
 	currentPolicyReport := v1alpha2.PolicyReport{}
 	policyReportRes, _ := dynamicClient.Resource(policyReportGvr).Namespace(data.ClusterInfo.Namespace).Get(
 		context.TODO(),

--- a/pkg/retriever/contentretriever.go
+++ b/pkg/retriever/contentretriever.go
@@ -13,10 +13,40 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/open-cluster-management/insights-client/pkg/types"
+	"github.com/open-cluster-management/insights-client/pkg/config"
+
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
+// ContentsMap contains all policy data
 var ContentsMap map[string]map[string]interface{}
 var lock = sync.RWMutex{}
+
+// InitializeContents ...
+func (r *Retriever) InitializeContents(hubID string) int {
+	return r.retrieveCCXContent(hubID)
+}
+
+// Function to make a GET HTTP call to get all the contents for reports
+func (r *Retriever) retrieveCCXContent(hubID string) int {
+	req, err := r.GetContentRequest(context.TODO(), hubID)
+	if err != nil {
+		glog.Warningf("Error creating HttpRequest with endpoint %s, %v", r.ContentURL, err)
+		return -1
+	}
+	contents, err := r.CallContents(req)
+	if err != nil {
+		glog.Warningf("Error calling for contents %s, %v", hubID, err)
+		return -1
+	}
+	r.CreateContents(contents)
+	return len(ContentsMap)
+}
 
 // GetContentRequest - Creates GET request for contents
 func (r *Retriever) GetContentRequest(ctx context.Context, hubID string) (*http.Request, error) {
@@ -60,28 +90,7 @@ func (r *Retriever) CallContents(req *http.Request) (types.ContentsResponse, err
 	return responseBody, err
 }
 
-// Function to make a GET HTTP call to get all the contents for reports
-func (r *Retriever) retrieveCCXContent(hubID string) int {
-	req, err := r.GetContentRequest(context.TODO(), hubID)
-	if err != nil {
-		glog.Warningf("Error creating HttpRequest with endpoint %s, %v", r.ContentURL, err)
-		return -1
-	}
-	contents, err := r.CallContents(req)
-	if err != nil {
-		glog.Warningf("Error calling for contents %s, %v", hubID, err)
-		return -1
-	}
-	r.CreateContents(contents)
-	return len(ContentsMap)
-}
-
-// InitializeContents ...
-func (r *Retriever) InitializeContents(hubID string) int {
-	return r.retrieveCCXContent(hubID)
-}
-
-// Populate json response from /contents call onto a Map to quick lookup
+// CreateContents - Populate json response from /contents call onto a Map to quick lookup
 func (r *Retriever) CreateContents(responseBody types.ContentsResponse) {
 	glog.Infof("Creating Contents from json ")
 	ContentsMap = make(map[string]map[string]interface{})
@@ -104,6 +113,71 @@ func (r *Retriever) CreateContents(responseBody types.ContentsResponse) {
 			ContentsMap[errorName] = errorMap
 			lock.Unlock()
 		}
+	}
+
+	// create a configmap containing insight content data
+	r.CreateInsightContentConfigmap()
+}
+
+// CreateInsightContentConfigmap Creates a configmap to store content data in open-cluster-management namespace
+func (r *Retriever) CreateInsightContentConfigmap() {
+	dynamicClient := config.GetDynamicClient()
+	var configMapData = make(map[string]string)
+	var configmapGvr = schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "configmaps",
+	}
+	for policy := range ContentsMap {
+		jsonStr, _ := json.Marshal(ContentsMap[policy])
+		configMapData[policy] = string(jsonStr)
+	}
+	configmap := &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "insight-content-data",
+			Namespace: "open-cluster-management",
+		},
+		Data: configMapData,
+	}
+	cmUnstructured, unstructuredErr := runtime.DefaultUnstructuredConverter.ToUnstructured(configmap)
+	if unstructuredErr != nil {
+		glog.Warningf("Error converting to unstructured.Unstructured: %s", unstructuredErr)
+	}
+	obj := &unstructured.Unstructured{Object: cmUnstructured}
+
+	configmapRes, _ := dynamicClient.Resource(configmapGvr).Namespace("open-cluster-management").Get(
+		context.TODO(),
+		"insight-content-data",
+		metav1.GetOptions{},
+	)
+	
+	var err error
+	if configmapRes != nil {
+		_, err = dynamicClient.Resource(configmapGvr).Namespace("open-cluster-management").Update(
+			context.TODO(),
+			obj,
+			metav1.UpdateOptions{},
+		)
+	} else {
+		_, err = dynamicClient.Resource(configmapGvr).Namespace("open-cluster-management").Create(
+			context.TODO(),
+			obj,
+			metav1.CreateOptions{},
+		)
+	}
+
+	if err != nil {
+		glog.Infof(
+			"Error while creating or updating ConfigMap: insight-content-data. Error: %v",
+			err,
+		)
+	} else {
+		glog.Infof(
+			"Successfully stored Insight content data in ConfigMap: insight-content-data",
+		)
 	}
 }
 

--- a/pkg/retriever/contentretriever.go
+++ b/pkg/retriever/contentretriever.go
@@ -127,11 +127,18 @@ func (r *Retriever) CreateContents(responseBody types.ContentsResponse) {
 
 // GetContentConfigMap ...
 func (r *Retriever) GetContentConfigMap(dynamicClient dynamic.Interface) (*unstructured.Unstructured) {
-	configmapRes, _ := dynamicClient.Resource(configmapGvr).Namespace(podNS).Get(
+	configmapRes, err := dynamicClient.Resource(configmapGvr).Namespace(podNS).Get(
 		context.TODO(),
 		"insight-content-data",
 		metav1.GetOptions{},
 	)
+
+	if err != nil {
+		glog.Infof(
+			"Error getting ConfigMap: insight-content-data. Error: %v",
+			err,
+		)
+	}
 
 	return configmapRes
 }

--- a/pkg/retriever/reportretriever.go
+++ b/pkg/retriever/reportretriever.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-cluster-management/insights-client/pkg/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 )
 
 // Retriever struct
@@ -267,7 +268,13 @@ func (r *Retriever) GetPolicyInfo(
 }
 
 // FetchClusters forwards the managed clusters to RetrieveCCXReports function
-func (r *Retriever) FetchClusters(monitor *monitor.Monitor, input chan types.ManagedClusterInfo, refreshToken bool) {
+func (r *Retriever) FetchClusters(
+	monitor *monitor.Monitor,
+	input chan types.ManagedClusterInfo,
+	refreshToken bool,
+	hubID string,
+	dynamicClient dynamic.Interface,
+) {
 	ticker := time.NewTicker(monitor.ClusterPollInterval)
 	defer ticker.Stop()
 	for ; true; <-ticker.C {
@@ -276,6 +283,11 @@ func (r *Retriever) FetchClusters(monitor *monitor.Monitor, input chan types.Man
 			if err != nil {
 				glog.Warningf("Unable to get CRC Token, Using previous Token: %v", err)
 			}
+		}
+		if len(ContentsMap) < 1 {
+			r.InitializeContents(hubID, dynamicClient)
+		} else if len(ContentsMap) > 0 && r.GetContentConfigMap(dynamicClient) == nil {
+			r.CreateInsightContentConfigmap(dynamicClient)
 		}
 		if len(monitor.ManagedClusterInfo) > 0 {
 			lock.RLock()


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#11809

### Description of changes
- Add logic to create a configmap `insight-content-data`, to store all insight content data
