### PR TITLE
Filter the openshift category label

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -41,6 +41,17 @@ func NewProcessor() *Processor {
 	return p
 }
 
+// FilterOpenshiftCategory Filter openshift category from list
+func FilterOpenshiftCategory(categories []string) string {
+	var filteredCategories []string
+	for i := range categories {
+		if categories[i] != "openshift" {
+			filteredCategories = append(filteredCategories, categories[i])
+		}
+	}
+	return strings.Join(filteredCategories, ",")
+}
+
 func getPolicyReportResults(
 	reports []types.ReportData,
 	clusterInfo types.ManagedClusterInfo,
@@ -61,7 +72,7 @@ func getPolicyReportResults(
 					Policy:      report.Key,
 					Description: contentData.Description,
 					Scored:      false,
-					Category:    strings.Join(contentData.Tags, ","),
+					Category:    FilterOpenshiftCategory(contentData.Tags),
 					Timestamp:   metav1.Timestamp{Seconds: time.Now().Unix(), Nanos: int32(time.Now().UnixNano())},
 					Result:      "fail",
 					Properties: map[string]string{

--- a/pkg/processor/reportprocessor_test.go
+++ b/pkg/processor/reportprocessor_test.go
@@ -119,3 +119,10 @@ func Test_createPolicyReport(t *testing.T) {
 	assert.Nil(t, unstructConvErr, "Expected policy report to be properly formatted. Got error: %v", unstructConvErr)
 	assert.Equal(t, len(createdPolicyReport.Results), 2, "Expected 2 issues to be found. Got %v", len(createdPolicyReport.Results))
 }
+
+func Test_filterOpenshiftCategory(t *testing.T) {
+	categories := []string{"test1", "openshift", "test2"}
+	filtered := FilterOpenshiftCategory(categories)
+
+	assert.Equal(t, "test1,test2", filtered, "Expected category list to exclude openshift")
+}


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

### Description of changes
- Openshift category label on policy violations is redundant. Adds a func to filter it out.
