### PR TITLE
Update the summary.fail count with total count of violations

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -169,6 +169,13 @@ func createPolicyReport(
 			Name: clusterInfo.Namespace,
 			Namespace: clusterInfo.Namespace,
 		},
+		Summary: v1alpha2.PolicyReportSummary{
+			Pass: 0,
+			Fail: len(clusterViolations),
+			Warn: 0,
+			Error: 0,
+			Skip: 0,
+		},
 	}
 	prUnstructured, unstructuredErr := runtime.DefaultUnstructuredConverter.ToUnstructured(policyreport)
 	if unstructuredErr != nil {
@@ -210,6 +217,7 @@ func updatePolicyReportViolations(
 	// merge existing PolicyReport results with new results
 	currentPolicyReport.Results = clusterViolations
 	currentPolicyReport.SetManagedFields(nil)
+	currentPolicyReport.Summary.Fail = len(clusterViolations)
 	data, marshalErr := json.Marshal(currentPolicyReport)
 	if marshalErr != nil {
 		glog.Warningf("Error Marshalling PolicyReport patch object for cluster %s: %v", clusterInfo.Namespace, marshalErr)


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:**  open-cluster-management/backlog#13900

### Description of changes
- We will keep the `summary.fail` count up to date with the total number of violations on a cluster so the cli response will display total count as seen below:

![Screen Shot 2021-07-01 at 2 20 36 PM](https://user-images.githubusercontent.com/14047925/124172201-873fc980-da77-11eb-948b-97291cb3441a.png)

