### PR TITLE
default unknown severity to low for grc policies

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -170,7 +170,7 @@ func convertSevFromGovernance(policySev string) string {
 	if severity, ok := sevMapping[policySev]; ok {
 		return severity.(string)
 	}
-	return "0"
+	return "1"
 }
 
 //getGovernanceResults creates a result object for each policy violation in the cluster


### PR DESCRIPTION
If a policy contains no severity or an incorrect string for severity, the severity will default to "0" which is invalid so the violation won't be reported as a metric, as seen in the issue below. This PR changes the default to "low" so those policies will still be reported as metrics.

Signed-off-by: Will Kutler <wkutler@redhat.com>

**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/16203

### Description of changes

