### PR TITLE
delete policyreport when there are no grc or insights violations

### DIFF
--- a/pkg/processor/reportprocessor.go
+++ b/pkg/processor/reportprocessor.go
@@ -147,9 +147,7 @@ func (p *Processor) createUpdatePolicyReports(input chan types.ProcessorData, dy
 		updatePolicyReportViolations(currentPolicyReport, clusterViolations, data.ClusterInfo, dynamicClient)
 	} else if currentPolicyReport.GetName() != "" && len(clusterViolations) == 0 {
 		// If PolicyReport no longer has violations && No policyresults from grc-> delete PolicyReport for cluster
-		if !grcViolationsPresent(currentPolicyReport) {
-			deletePolicyReport(data.ClusterInfo, dynamicClient)
-		}
+		deletePolicyReport(data.ClusterInfo, dynamicClient)
 
 	} else if currentPolicyReport.GetName() == "" && len(clusterViolations) == 0 {
 		glog.Infof(
@@ -365,15 +363,6 @@ func updatePolicyReportViolations(
 			clusterInfo.ClusterID,
 		)
 	}
-}
-
-func grcViolationsPresent(currentPolicyReport v1alpha2.PolicyReport) bool {
-	for _, result := range currentPolicyReport.Results {
-		if result.Source == "grc" {
-			return true
-		}
-	}
-	return false
 }
 
 func deletePolicyReport(clusterInfo types.ManagedClusterInfo, dynamicClient dynamic.Interface) {


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/17260

### Description of changes
Previously the client would not delete a policyreport if there were GRC violations in the existing policyreport, but it would also not update the policyreport unless new violations were found. This led to some weird scenarios where if a GRC violation was the only violation in the policyreport, it would continue to show up even after being remediated until another violation was reported. 

